### PR TITLE
right-to-left language support

### DIFF
--- a/project/Dist-FSG/less/grid/flawless-grid.less
+++ b/project/Dist-FSG/less/grid/flawless-grid.less
@@ -59,10 +59,18 @@
 	.mixin(@columns:@columns)  when (ispixel(@total-width))  {
 		width: @gridsystem-width;
 		margin-left:@column-gutter-width* -1;
+		[dir="rtl"] & {
+			margin-left: 0;
+			margin-right: @column-gutter-width* -1;
 		}
+	}
 	.mixin(@columns:@columns)  when (ispercentage(@total-width))  {
 		width: @total-width + @p-column-gutter-width; // See below comment regarding @p-column-gutter-width
 		margin-left:@p-column-gutter-width* -1; // Technically should be @p-column-gutter-width*-1 but browser rounding breaks the layout. Will be testing this further to eliminate the error this introduces.
+		[dir="rtl"] & {
+			margin-left: 0;
+			margin-right: @p-column-gutter-width* -1;
+		}
 	}
 	.mixin(@columns);
 	overflow:hidden;
@@ -83,11 +91,22 @@
 
 .column(@columns:@columns){
 	float: left;
+	[dir="rtl"] & {
+		float: right;
+	}
 	.mixin(@columns:@columns)  when (ispixel(@total-width))  {
 		margin-left: @column-gutter-width;
+		[dir="rtl"] & {
+			margin-left: 0;
+			margin-right: @column-gutter-width;
+		}
 	}
 	.mixin(@columns:@columns)  when (ispercentage(@total-width))  {
 		margin-left: @column-gutter-width; // Technically should be @p-column-gutter-width*-1 but browser rounding breaks the layout. Will be testing this further to eliminate the error this introduces.
+		[dir="rtl"] & {
+			margin-left: 0;
+			margin-right: @column-gutter-width;
+		}
 	}
 	.mixin(@columns);
 }
@@ -108,10 +127,18 @@
 	.mixin(@offset:1,@columns:@columns)  when (ispixel(@total-width))  {
 		@calculated-column-width: (((@gutter-width+@column-width)*@offset)-@gutter-width)*1px;
 		margin-left: @calculated-column-width+(@column-gutter-width*2);
+		[dir="rtl"] & {
+			margin-left: 0;
+			margin-right: @calculated-column-width+(@column-gutter-width*2);
+		}
 	}
 	.mixin(@offset:1,@columns:@columns)  when (ispercentage(@total-width))  {
 		@calculated-column-width: @total-width*((((@gutter-width+@column-width)*@offset)-@gutter-width) / @gridsystem-width);
 		margin-left: @calculated-column-width+(@column-gutter-width*2);
+		[dir="rtl"] & {
+			margin-left: 0;
+			margin-right: @calculated-column-width+(@column-gutter-width*2);
+		}
 	}
 	.mixin(@offset,@columns);
 }


### PR DESCRIPTION
These changes add support for right-to-left languages. Unlike some grid systems that support RTL using a compile-time flag (requiring two separate compiled CSS files), this approach leverages an attribute selector that targets a parent element with the ["dir" attribute](http://www.w3.org/TR/html401/struct/dirlang.html#h-8.2) set to `rtl`. When that attribute/value combination is present, we flip any direction-specific CSS rules (e.g. float, margin-left) to their inverse.

To use the grid system in right-to-left mode, simply add `dir="rtl"` to any parent element in your document:

``` html
<html dir="rtl">
</html>
```
